### PR TITLE
Implement API that allows providing data for modules.

### DIFF
--- a/rules-callback.c
+++ b/rules-callback.c
@@ -47,6 +47,11 @@ int stdScanCallback(int message, void *message_data, void *user_data) {
 #endif
       }
     }
+  } else if (message == CALLBACK_MSG_IMPORT_MODULE) {
+    YR_MODULE_IMPORT* module_import = (YR_MODULE_IMPORT*) message_data;
+    struct getModuleData_return r = getModuleData(user_data, (char*) module_import->module_name);
+    module_import->module_data = r.r0;
+    module_import->module_data_size = r.r1;
   }
   return CALLBACK_CONTINUE;
 }

--- a/rules_yara37_test.go
+++ b/rules_yara37_test.go
@@ -1,0 +1,26 @@
+//+build !yara3.3,!yara3.4,!yara3.5,!yara3.6
+
+package yara
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestModuleData(t *testing.T) {
+	buf := &bytes.Buffer{}
+	buf.Write([]byte("not used"))
+	opts := ScanOptions{
+		ModulesData: map[string][]byte{
+			"tests": []byte("test module data"),
+		},
+	}
+	r := makeRules(t, `
+		import "tests"
+		rule t { condition: tests.module_data == "test module data" }`)
+	if m, err := r.ScanMemWithOptions(buf.Bytes(), opts); err != nil {
+		t.Errorf("Error %s", err)
+	} else if len(m) != 1 {
+		t.Error("tests.module_data != \"test module data\"")
+	}
+}


### PR DESCRIPTION
Most YARA modules use the data being scanned as their only input, but some others needs additional data (example: the "cuckoo" module). With the existing API the user didn't have a way for providing additional data to modules. This commit implements a new set of API functions that accept a ScanOptions structure, where one the fields is a map of strings to byte slices that provides additional data for modules.

As the new API is more general, the existing functions where implemented using the new ones.